### PR TITLE
Improve documentation and add test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # wol-proxy
-A set of Rust programs to transparently wake up a high-power server on demand
+
+A collection of small Rust utilities that make it easy to run a power hungry
+machine only when it's actually needed. The tools in this repository can wake
+machines over the network using Wake-on-LAN and proxy connections until the
+machine is ready to serve them.
+
+## Components
+
+### `wol`
+
+`wol` listens on a TCP port and proxies incoming connections to a target
+machine. If the target machine is asleep the proxy first sends a Wake-on-LAN
+packet and waits for the machine to come online before forwarding the
+connection.
+
+Example:
+
+```bash
+wol-proxy wol --mac aa:bb:cc:dd:ee:ff --target 192.0.2.10:22 --bind 0.0.0.0:2222
+```
+
+The above command exposes an SSH service on port `2222`. When a client connects
+it wakes the real server at `192.0.2.10` and then proxies the SSH session.
+
+### `keepawake`
+
+`keepawake` is a lightweight TCP proxy that holds a system wake lock while a
+connection is active and for a short period afterwards. This is useful to keep a
+machine from suspending in the middle of a long running connection.
+
+Example:
+
+```bash
+wol-proxy keepawake --target 192.0.2.10:80 --bind 0.0.0.0:8080
+```
+
+## Building
+
+This project uses [Cargo](https://doc.rust-lang.org/cargo/). To build the
+binaries run:
+
+```bash
+cargo build --release
+```
+
+The compiled binaries can be found in `target/release/`.
+
+## Testing
+
+The repository contains unit and integration tests covering the proxying
+utilities. Run all tests with:
+
+```bash
+cargo test
+```
+
+## License
+
+This project is licensed under the terms of the MIT license. See the
+[LICENSE](LICENSE) file for details.

--- a/src/bin/wol.rs
+++ b/src/bin/wol.rs
@@ -97,6 +97,61 @@ fn parse_mac(mac: &str) -> Result<[u8; 6]> {
     Ok(out)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    #[test]
+    fn parse_mac_parses_bytes() {
+        let mac = parse_mac("aa:bb:cc:dd:ee:ff").unwrap();
+        assert_eq!(mac, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    }
+
+    #[test]
+    fn parse_mac_rejects_invalid() {
+        assert!(parse_mac("not a mac").is_err());
+    }
+
+    #[tokio::test]
+    async fn ping_localhost_succeeds() {
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(ping(&ip, Duration::from_secs(1)).await);
+    }
+
+    #[tokio::test]
+    async fn handle_client_proxies_data() {
+        // Start echo server that will act as the real target
+        let echo = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let echo_addr = echo.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = echo.accept().await.unwrap();
+            let mut buf = [0u8; 32];
+            let n = stream.read(&mut buf).await.unwrap();
+            stream.write_all(&buf[..n]).await.unwrap();
+        });
+
+        // Start listener representing the proxy and spawn handle_client
+        let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = proxy.accept().await.unwrap();
+            let mac = [0, 1, 2, 3, 4, 5];
+            handle_client(stream, &echo_addr, &mac, 1).await.unwrap();
+        });
+
+        // Client connects to proxy and ensures data is echoed back
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        client.write_all(b"ping").await.unwrap();
+        let mut buf = [0u8; 4];
+        client.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"ping");
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let args = Args::parse();

--- a/tests/keepawake_cli.rs
+++ b/tests/keepawake_cli.rs
@@ -1,0 +1,55 @@
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn keepawake_cli_proxies_connections() {
+    // Start echo server
+    let echo_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let echo_port = echo_listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::from_std(echo_listener).unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 32];
+        let n = stream.read(&mut buf).await.unwrap();
+        stream.write_all(&buf[..n]).await.unwrap();
+    });
+
+    // Reserve a port for proxy to bind
+    let proxy_port = {
+        let l = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = l.local_addr().unwrap().port();
+        drop(l);
+        port
+    };
+
+    // Spawn keepawake binary
+    let mut child = Command::new(env!("CARGO_BIN_EXE_keepawake"))
+        .args([
+            "--target", &format!("127.0.0.1:{}", echo_port),
+            "--bind", &format!("127.0.0.1:{}", proxy_port),
+            "--timeout", "1",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn keepawake");
+
+    // Connect to proxy once it is ready
+    let mut client = loop {
+        match TcpStream::connect(("127.0.0.1", proxy_port)).await {
+            Ok(stream) => break stream,
+            Err(_) => sleep(Duration::from_millis(50)).await,
+        }
+    };
+
+    client.write_all(b"pong").await.unwrap();
+    let mut buf = [0u8; 4];
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"pong");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/tests/wol_cli.rs
+++ b/tests/wol_cli.rs
@@ -1,0 +1,56 @@
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn wol_cli_proxies_connections() {
+    // Start echo server
+    let echo_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let echo_port = echo_listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::from_std(echo_listener).unwrap();
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 32];
+        let n = stream.read(&mut buf).await.unwrap();
+        stream.write_all(&buf[..n]).await.unwrap();
+    });
+
+    // Reserve a port for the proxy to bind to
+    let proxy_port = {
+        let l = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = l.local_addr().unwrap().port();
+        drop(l);
+        port
+    };
+
+    // Spawn the wol binary
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wol"))
+        .args([
+            "--mac", "00:11:22:33:44:55",
+            "--target", &format!("127.0.0.1:{}", echo_port),
+            "--bind", &format!("127.0.0.1:{}", proxy_port),
+            "--timeout", "1",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn wol");
+
+    // Wait for the proxy to start accepting connections
+    let mut client = loop {
+        match TcpStream::connect(("127.0.0.1", proxy_port)).await {
+            Ok(stream) => break stream,
+            Err(_) => sleep(Duration::from_millis(50)).await,
+        }
+    };
+
+    client.write_all(b"ping").await.unwrap();
+    let mut buf = [0u8; 4];
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"ping");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- Expand README with usage examples, build and test instructions
- Add unit tests for wake-on-LAN proxy logic
- Add integration tests exercising `wol` and `keepawake` binaries

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c5aee0578c83338244a20b4ca00e87